### PR TITLE
Use safer mutex

### DIFF
--- a/lib/redis/semaphore.rb
+++ b/lib/redis/semaphore.rb
@@ -129,9 +129,9 @@ class Redis
   private
     def simple_mutex(key_name, expires = nil)
       key_name = namespaced_key(key_name) if key_name.kind_of? Symbol
-      token = @redis.getset(key_name, API_VERSION)
+      token = @redis.setnx(key_name, API_VERSION)
 
-      return false unless token.nil?
+      return false unless token
       @redis.expire(key_name, expires) unless expires.nil?
 
       begin


### PR DESCRIPTION
@djspinmonkey Does this look like the mutex fix we discussed? It passes the tests. Experimentation suggests that the ruby redis client returns `true` or `false` for `setnx` rather than the `1` or `0` that redis itself uses.
