### PR TITLE
Fix typing Redis return value in simple_mutex

### DIFF
--- a/lib/redis/semaphore.rb
+++ b/lib/redis/semaphore.rb
@@ -145,7 +145,7 @@ class Redis
       if !acquired
         locked_at = @redis.get(mutex_key).to_i
         return false if !lock_expired(locked_at, timeout)
-        locked_at_2 = @redis.getset(mutex_key, Time.now.to_i)
+        locked_at_2 = @redis.getset(mutex_key, Time.now.to_i).to_i
         return false if locked_at_2 != locked_at
       end
 


### PR DESCRIPTION
@adamdicarlo for review

Redis returns strings, and it turns out strings aren't equal to numbers! 

That essentially meant that we were never releasing stale locks.
